### PR TITLE
fix(me): 修复热图年份校验与活跃天数字段类型

### DIFF
--- a/src/main/java/com/seuoj/seuojbackend/controller/api/MeController.java
+++ b/src/main/java/com/seuoj/seuojbackend/controller/api/MeController.java
@@ -5,6 +5,7 @@ import com.seuoj.seuojbackend.common.Result;
 import com.seuoj.seuojbackend.common.RoleType;
 import com.seuoj.seuojbackend.service.SubmissionService;
 import com.seuoj.seuojbackend.vo.me.MeHeatmapVO;
+import jakarta.validation.constraints.Pattern;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -22,7 +23,8 @@ public class MeController {
 
     @RequireRole({RoleType.USER})
     @GetMapping("/heatmap")
-    public Result<MeHeatmapVO> heatmap(@RequestParam String year) {
+    public Result<MeHeatmapVO> heatmap(@RequestParam
+                                       @Pattern(regexp = "^\\d{4}$", message = "年份格式必须为4位数字") String year) {
         return Result.success(submissionService.getHeatmap(year));
     }
 }

--- a/src/main/java/com/seuoj/seuojbackend/service/SubmissionService.java
+++ b/src/main/java/com/seuoj/seuojbackend/service/SubmissionService.java
@@ -47,7 +47,6 @@ import org.springframework.transaction.support.TransactionTemplate;
 public class SubmissionService {
 
     private static final int MAX_CODE_BYTES = 65535;
-    private static final Pattern YEAR_PATTERN = Pattern.compile("\\d{4}");
 
     private final SubmissionMapper submissionMapper;
     private final ProblemMapper problemMapper;
@@ -247,9 +246,6 @@ public class SubmissionService {
     }
 
     public MeHeatmapVO getHeatmap(String year) {
-        if (year == null || !YEAR_PATTERN.matcher(year).matches()) {
-            throw new BadRequestException("年份必须是4位数字");
-        }
         var userContext = UserContextHolder.get();
         if (userContext == null || userContext.getUserId() == null) {
             throw new NotFoundException("用户未登录");
@@ -265,7 +261,7 @@ public class SubmissionService {
 
         HeatmapSummaryVO summary = new HeatmapSummaryVO();
         summary.setTotal(total);
-        summary.setActiveDays(String.valueOf(days.size()));
+        summary.setActiveDays(days.size());
 
         MeHeatmapVO result = new MeHeatmapVO();
         result.setYear(year);

--- a/src/main/java/com/seuoj/seuojbackend/vo/me/HeatmapSummaryVO.java
+++ b/src/main/java/com/seuoj/seuojbackend/vo/me/HeatmapSummaryVO.java
@@ -7,5 +7,5 @@ import lombok.Data;
 public class HeatmapSummaryVO {
     private Long total;
     @JsonProperty("active_days")
-    private String activeDays;
+    private Integer activeDays;
 }


### PR DESCRIPTION
- 在接口参数中添加了对年份格式的正则校验，限制为4位数字
- 移除服务层中的年份格式校验代码，统一由接口层负责
- 将热图活跃天数字段类型由String调整为Integer，避免不必要的类型转换