### PR TITLE
feat: add prev/next problem navigation API

### DIFF
--- a/src/main/java/com/seuoj/seuojbackend/mapper/ProblemMapper.java
+++ b/src/main/java/com/seuoj/seuojbackend/mapper/ProblemMapper.java
@@ -6,6 +6,7 @@ import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.seuoj.seuojbackend.entity.Problem;
 import com.seuoj.seuojbackend.vo.problem.ProblemDetailVO;
 import com.seuoj.seuojbackend.vo.problem.ProblemListItemVO;
+import com.seuoj.seuojbackend.vo.problem.ProblemNeighborsVO;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.ibatis.annotations.Mapper;
@@ -97,4 +98,23 @@ public interface ProblemMapper extends BaseMapper<Problem> {
      * 统计题目的有效比赛提交关联数（contest_submission.is_del=0 且关联 contest/submission 未删除）。
      */
     long countActiveContestSubmissionsByProblemId(@Param("problemId") Long problemId);
+
+    /**
+     * 获取题目在指定上下文中的 sort_order
+     */
+    Integer selectSortOrderInContest(@Param("contestId") Long contestId, @Param("problemId") Long problemId);
+    Integer selectSortOrderInProblemSet(@Param("problemSetId") Long problemSetId, @Param("problemId") Long problemId);
+    Integer selectSortOrderInAssignment(@Param("assignmentId") Long assignmentId, @Param("problemId") Long problemId);
+
+    /**
+     * 按题目列表默认排序（P去前缀后数值升序），用窗口函数一次查出前后 pid
+     */
+    ProblemNeighborsVO selectNeighborsDirect(@Param("pid") String pid, @Param("includeNonPublic") boolean includeNonPublic);
+
+    /**
+     * 按 sort_order 顺序获取前后 pid
+     */
+    ProblemNeighborsVO selectNeighborsInContest(@Param("contestId") Long contestId, @Param("pid") String pid);
+    ProblemNeighborsVO selectNeighborsInProblemSet(@Param("problemSetId") Long problemSetId, @Param("pid") String pid);
+    ProblemNeighborsVO selectNeighborsInAssignment(@Param("assignmentId") Long assignmentId, @Param("pid") String pid);
 }

--- a/src/main/java/com/seuoj/seuojbackend/service/ProblemService.java
+++ b/src/main/java/com/seuoj/seuojbackend/service/ProblemService.java
@@ -294,6 +294,20 @@ public class ProblemService {
         // 判断是否可以编辑删除题目
         problemDetail.setCanWrite(permissionService.hasPermission(userId, ResourceType.PROBLEM, problem.getId(), PermissionOp.WRITE));
 
+        // 计算前后题目 pid（用于题目详情页翻页）
+        ProblemNeighborsVO neighbors = null;
+        boolean includeNonPublic = canCurrentUserViewPrivateProblems();
+        switch (query.sourceType()) {
+            case DIRECT -> neighbors = problemMapper.selectNeighborsDirect(query.pid(), includeNonPublic);
+            case CONTEST -> neighbors = problemMapper.selectNeighborsInContest(query.ownerId(), query.pid());
+            case PROBLEM_SET -> neighbors = problemMapper.selectNeighborsInProblemSet(query.ownerId(), query.pid());
+            case ASSIGNMENT -> neighbors = problemMapper.selectNeighborsInAssignment(query.ownerId(), query.pid());
+        }
+        if (neighbors != null) {
+            problemDetail.setPrevPid(neighbors.getPrevPid());
+            problemDetail.setNextPid(neighbors.getNextPid());
+        }
+
         return problemDetail;
     }
 

--- a/src/main/java/com/seuoj/seuojbackend/vo/problem/ProblemDetailVO.java
+++ b/src/main/java/com/seuoj/seuojbackend/vo/problem/ProblemDetailVO.java
@@ -33,4 +33,10 @@ public class ProblemDetailVO {
     // 是否可以写题目（包括编辑和删除）
     @JsonProperty("can_write")
     private Boolean canWrite;
+
+    @JsonProperty("prev_pid")
+    private String prevPid;
+
+    @JsonProperty("next_pid")
+    private String nextPid;
 }

--- a/src/main/java/com/seuoj/seuojbackend/vo/problem/ProblemNeighborsVO.java
+++ b/src/main/java/com/seuoj/seuojbackend/vo/problem/ProblemNeighborsVO.java
@@ -1,0 +1,13 @@
+package com.seuoj.seuojbackend.vo.problem;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class ProblemNeighborsVO {
+    @JsonProperty("prev_pid")
+    private String prevPid;
+
+    @JsonProperty("next_pid")
+    private String nextPid;
+}

--- a/src/main/resources/mapper/ProblemMapper.xml
+++ b/src/main/resources/mapper/ProblemMapper.xml
@@ -230,6 +230,77 @@
           AND ps.is_del = 0
     </select>
 
+    <!-- 获取题目在指定上下文中的 sort_order -->
+    <select id="selectSortOrderInContest" resultType="java.lang.Integer">
+        SELECT rel.sort_order FROM contest_problem_rel rel
+        WHERE rel.contest_id = #{contestId} AND rel.problem_id = #{problemId} AND rel.is_del = 0
+    </select>
+
+    <select id="selectSortOrderInProblemSet" resultType="java.lang.Integer">
+        SELECT rel.sort_order FROM problem_set_problem_rel rel
+        WHERE rel.problem_set_id = #{problemSetId} AND rel.problem_id = #{problemId} AND rel.is_del = 0
+    </select>
+
+    <select id="selectSortOrderInAssignment" resultType="java.lang.Integer">
+        SELECT rel.sort_order FROM assignment_problem_rel rel
+        WHERE rel.assignment_id = #{assignmentId} AND rel.problem_id = #{problemId} AND rel.is_del = 0
+    </select>
+
+    <!-- 题目详情页翻页：窗口函数一次查出前后 pid -->
+    <resultMap id="ProblemNeighborsMap" type="com.seuoj.seuojbackend.vo.problem.ProblemNeighborsVO">
+        <result column="prev_pid" property="prevPid"/>
+        <result column="next_pid" property="nextPid"/>
+    </resultMap>
+
+    <select id="selectNeighborsDirect" resultMap="ProblemNeighborsMap">
+        SELECT prev_pid, next_pid FROM (
+            SELECT p.pid,
+                   LAG(p.pid)  OVER w AS prev_pid,
+                   LEAD(p.pid) OVER w AS next_pid
+            FROM problem p
+            WHERE p.is_del = 0
+            <if test="!includeNonPublic">AND p.is_public = 1</if>
+            WINDOW w AS (ORDER BY
+                CASE WHEN p.pid REGEXP '^[A-Za-z][0-9]+$'
+                     THEN CAST(SUBSTRING(p.pid, 2) AS UNSIGNED)
+                     ELSE 18446744073709551615 END,
+                p.pid)
+        ) t WHERE t.pid = #{pid}
+    </select>
+
+    <select id="selectNeighborsInContest" resultMap="ProblemNeighborsMap">
+        SELECT prev_pid, next_pid FROM (
+            SELECT p.pid,
+                   LAG(p.pid)  OVER (ORDER BY rel.sort_order) AS prev_pid,
+                   LEAD(p.pid) OVER (ORDER BY rel.sort_order) AS next_pid
+            FROM problem p
+            JOIN contest_problem_rel rel ON p.id = rel.problem_id
+            WHERE rel.contest_id = #{contestId} AND rel.is_del = 0 AND p.is_del = 0
+        ) t WHERE t.pid = #{pid}
+    </select>
+
+    <select id="selectNeighborsInProblemSet" resultMap="ProblemNeighborsMap">
+        SELECT prev_pid, next_pid FROM (
+            SELECT p.pid,
+                   LAG(p.pid)  OVER (ORDER BY rel.sort_order) AS prev_pid,
+                   LEAD(p.pid) OVER (ORDER BY rel.sort_order) AS next_pid
+            FROM problem p
+            JOIN problem_set_problem_rel rel ON p.id = rel.problem_id
+            WHERE rel.problem_set_id = #{problemSetId} AND rel.is_del = 0 AND p.is_del = 0
+        ) t WHERE t.pid = #{pid}
+    </select>
+
+    <select id="selectNeighborsInAssignment" resultMap="ProblemNeighborsMap">
+        SELECT prev_pid, next_pid FROM (
+            SELECT p.pid,
+                   LAG(p.pid)  OVER (ORDER BY rel.sort_order) AS prev_pid,
+                   LEAD(p.pid) OVER (ORDER BY rel.sort_order) AS next_pid
+            FROM problem p
+            JOIN assignment_problem_rel rel ON p.id = rel.problem_id
+            WHERE rel.assignment_id = #{assignmentId} AND rel.is_del = 0 AND p.is_del = 0
+        ) t WHERE t.pid = #{pid}
+    </select>
+
     <!-- 删除检查：题目是否存在有效比赛提交关联 -->
     <select id="countActiveContestSubmissionsByProblemId" resultType="java.lang.Long">
         SELECT COUNT(1)


### PR DESCRIPTION
## 摘要
将 `prev_pid` / `next_pid` 嵌入现有的 `ProblemDetailVO` 中，这样前端就可以在同一个详情响应中获取相邻的 PID

导航排序遵循查看的上下文：
- **DIRECT**：按 PID 数字排序（去除P前缀，作为无符号整数排序），与题目列表页保持一致
- **CONTEST / PROBLEM_SET / ASSIGNMENT**：遵循关联关系的 `sort_order`

## 检查排序逻辑，在按照pid排序前根据sourceType检查
- **ProblemDetailVO**：添加 `prev_pid` / `next_pid` 字段
- **ProblemMapper**：使用 `LAG`/`LEAD` 窗口函数添加相邻项查询，每种上下文类型对应一个查询
- **ProblemService.getProblemDetail**：根据 `sourceType` 进行判断以选择正确的相邻项查询，然后设置对应字段
- **ProblemNeighborsVO**：保留作为内部 mapper 结果的 DTO

## 设计决策
- 相邻项在现有的 `getProblemDetail` 方法内部进行计算
- 使用与题目列表页完全相同的 `ORDER BY` 配合窗口函数（`LAG`/`LEAD`），确保排序正确
- 相邻项保持在各自的上下文（contest/problem_set/assignment）范围内